### PR TITLE
framework for predicting TMK from FSI features

### DIFF
--- a/fragile_state_index/datasets.py
+++ b/fragile_state_index/datasets.py
@@ -1,0 +1,124 @@
+import load_tmk
+import load_fsi
+import numpy as np
+import pandas
+
+#
+
+_df_tmk = load_tmk.load()
+
+# Fragile State Index 
+_df_fsi = load_fsi.load_joined()
+load_fsi.shorten_indicators(_df_fsi)
+
+_df_fsi = load_fsi.to_long(_df_fsi)
+
+
+
+def build_fsi_predicting_tmk(k=2,L=1):
+    '''
+    Inputs:
+        k: integer; number of consecutive years of FSI data to use.
+            Feature vectors will be length 12k. (Default: 2)
+        L: integer; years after observed data to make a prediction
+            of a TMK event. L=1 corresponds to "the next year".
+            (Default: 1)
+    Outputs:
+        X : array shape (n,12*k) of FSI data by row.
+        y : array shape (n,) of TMK event data.
+        meta : dictionary containing auxilliary information;
+            'features' : array of strings of feature names
+            
+    These are designed from the perspective of performing 
+    a classifcation
+        
+        
+    '''
+    df_tmk = _df_tmk[ _df_tmk['year'] >= 2006 ]
+    df_tmk.replace( load_tmk.tmk_to_fsi, inplace=True )
+
+    tmk_actors = df_tmk['country'].str.split(', ')
+    tmk_actors_unique = np.unique( np.concatenate(tmk_actors.values) )
+
+
+    # convert to "multi-index" pivot table; a 3D object (Country, Year, Indicator);
+    # accessed first by Year; then, rows are the data for that year.
+    df_fsi_pivot = _df_fsi.pivot_table(values='value', index='Country', columns=['Year','Indicator'])
+
+    # replace "country" data accounting for informal comma separated lists
+    # in the original TMK data.
+    df_tmk2 = load_tmk.expand_countries(df_tmk)
+
+    # parameters
+    #k = 2
+    #L = 1
+    
+    ###
+    # Build indicator dataset on (country,year) for a TMK event.
+    
+    df_p = df_tmk2.pivot_table(values='tmk.ordinal', index='country', columns='year')
+    df_p.fillna(0., inplace=True)
+    
+    tmk_minyear = df_p.columns.min()
+    tmk_maxyear = 2023 # hard code...
+    
+    # pad with non-TMK years where needed
+    for i in range(tmk_minyear,tmk_maxyear + 1):
+        if i not in df_p.columns:
+            df_p[i] = np.zeros(df_p.shape[0])
+    
+    # pad with non-TMK countries where needed
+    all_fsi_countries = _df_fsi['Country'].unique()
+    non_tmk_countries = np.setdiff1d( all_fsi_countries, df_p.index )
+    _df_null = pandas.DataFrame(data = np.zeros( (len(non_tmk_countries), df_p.shape[1] ) ),
+                                columns = df_p.columns, 
+                                index = non_tmk_countries
+                                )
+    
+    #
+    df_p = df_p.append(_df_null)
+    df_p.sort_index(inplace=True)
+    
+    # TODO: Code assumes row ordering is consistent.
+    # CANNOT PROCEED WITH CODE AS-IS IF THIS IS NOT TRUE.
+    assert all(df_p.index == df_fsi_pivot.index)
+    
+    #
+    
+    Xstack = []
+    ystack = []
+    countries = []
+    # for each year i after 2006+k+L-1 (inclusive),
+    for i in range(tmk_minyear+k+L-1, tmk_maxyear+1):
+        # y_i : year i from TMK dataset
+        y_i = df_p[i].values
+        
+        # X_i : year i-L-k+1 to year i-L inclusive from the FSI dataset.
+        # array dimensions go (year, country, indicator)
+        X_i = np.array([ df_fsi_pivot[i-L-k+1+j].values for j in range(k)])
+        # glue together data for a single country
+        X_i = np.concatenate(X_i, axis=1)
+        
+        # Filter out any missing data.
+        to_keep = ~np.any(np.isnan(X_i), axis=1)
+        
+        Xstack.append( X_i[to_keep] )
+        ystack.append( y_i[to_keep] )
+        
+        countries.append( df_p.index.values )
+        # e.g. if k=2, L=1, then start at 2008 (prediction year); 
+        # years 2008-1-2+1 (=2006) to 2008-1 (=2007) (TMI data years).
+    #
+    
+    X = np.concatenate(Xstack, axis=0)
+    y = np.concatenate(ystack)
+    
+    features_plain = df_fsi_pivot[tmk_minyear].columns.values # C1, C2, ..., S2, S1
+    features = np.concatenate([['%s_Y%i'%(fp, j) for fp in features_plain] for j in range(k)])
+    
+    countries = np.array(countries)
+    
+    # must have no NaN at this point!
+    assert( np.all(~np.isnan(X)) and np.all(~np.isnan(y)) )
+    return X,y,{'features':features, 'countries':countries}
+#

--- a/fragile_state_index/datasets.py
+++ b/fragile_state_index/datasets.py
@@ -56,7 +56,9 @@ def build_fsi_predicting_tmk(k=2,L=1):
     ###
     # Build indicator dataset on (country,year) for a TMK event.
     
-    df_p = df_tmk2.pivot_table(values='tmk.ordinal', index='country', columns='year')
+    # TODO: optional variable to pass to select the column 
+    # to build the pivot table out on (hence to do classification/regression on)
+    df_p = df_tmk2.pivot_table(values='tmk', index='country', columns='year')
     df_p.fillna(0., inplace=True)
     
     tmk_minyear = df_p.columns.min()

--- a/fragile_state_index/fsi_analysis3.py
+++ b/fragile_state_index/fsi_analysis3.py
@@ -113,7 +113,7 @@ if True:
     # figure polish
     ax.set_xlim(-max(np.abs(ax.get_xlim())), max(np.abs(ax.get_xlim())))
     ax.axvline(0,c='k', lw=3)
-    ax.set_title('FSI indicator feature importance (predicting TMK year%i)'%k, loc='left', fontsize=24)
+    ax.set_title('FSI indicator feature importance (predicting TMK year%i)'%(k+L-1), loc='left', fontsize=24)
     seaborn.move_legend(ax, loc='upper left')
     
     fig.savefig('FSI_predicting_TMK_k%i_L%i.png'%(k,L), bbox_inches='tight')

--- a/fragile_state_index/fsi_analysis3.py
+++ b/fragile_state_index/fsi_analysis3.py
@@ -1,0 +1,88 @@
+#import pandas
+#import seaborn as sns
+from matplotlib import pyplot as plt
+import pandas
+import numpy as np
+
+import load_fsi
+import vis_tools_fsi
+import load_tmk
+
+plt.rcParams.update({'font.size': 14})
+plt.style.use('seaborn-whitegrid')
+
+##
+
+# Targeted Mass Killings data since 2006
+df_tmk = load_tmk.load()
+
+df_tmk = df_tmk[ df_tmk['year'] >= 2006 ]
+df_tmk.replace( load_tmk.tmk_to_fsi, inplace=True )
+
+tmk_actors = df_tmk['country'].str.split(', ')
+tmk_actors_unique = np.unique( np.concatenate(tmk_actors.values) )
+
+# replace "country" data accounting for informal comma separated lists
+# in the original TMK data.
+df_tmk2 = load_tmk.expand_countries(df_tmk)
+
+# Fragile State Index 
+df_fsi = load_fsi.load_joined()
+load_fsi.shorten_indicators(df_fsi)
+
+df_fsi = load_fsi.to_long(df_fsi)
+
+'''
+RESEARCH QUESTION:
+    
+    Given the FSI data from k years; year_{i}, year_{i-1}, ..., year_{i-k+1}, 
+    predict the likelihood of an event at year_{i+L}.
+    
+    k : length of observation/memory
+    L : forecast length (start with L=1).
+    
+    There are 12 indicators; so we are mapping 12k dimensions to 1 
+    dimension. 
+    
+    Side-issue: if an event is happening or has happened, 
+    data becomes biased/polluted/otherwise affected which may 
+    affect downstream results.
+'''
+
+# parameters
+k = 2
+L = 1
+
+###
+# Build indicator dataset on (country,year) for a TMK event.
+
+df_p = df_tmk2.pivot_table(values='tmk', index='country', columns='year')
+df_p.fillna(0., inplace=True)
+
+# pad with non-TMK years where needed
+for i in range(2006,2023 + 1):
+    if i not in df_p.columns:
+        df_p[i] = np.zeros(df_p.shape[0])
+
+# pad with non-TMK countries where needed
+all_fsi_countries = df_fsi['Country'].unique()
+non_tmk_countries = np.setdiff1d( all_fsi_countries, df_p.index )
+_df_null = pandas.DataFrame(data = np.zeros( (len(non_tmk_countries), df_p.shape[1] ) ),
+                            columns = df_p.columns, 
+                            index = non_tmk_countries,
+)
+
+#
+df_p = df_p.append(_df_null)
+
+X = []
+y = []
+# for each year i after 2006+k+L-1 (inclusive),
+    # y_i : year i from TMK dataset
+    # X_i : year i-L-k+1 to year i-L inclusive from the FSI dataset.
+    # e.g. if k=2, L=1, then start at 2008 (prediction year); 
+    # years 2008-1-2+1 (=2006) to 2008-1 (=2007) (TMI data years).
+
+
+
+

--- a/fragile_state_index/fsi_analysis3.py
+++ b/fragile_state_index/fsi_analysis3.py
@@ -19,7 +19,7 @@ import seaborn
 
 ######
 
-plt.rcParams.update({'font.size': 14})
+plt.rcParams.update({'font.size': 16})
 plt.style.use('seaborn-whitegrid')
 
 ########
@@ -157,7 +157,7 @@ tests = np.zeros((nboots, 2*ntmk))
 aucrocs = np.zeros(nboots)
 
 for i in range(nboots):
-    model = linear_model.ElasticNet(max_iter=1e4, l1_ratio=0.5) # idk lol
+    model = linear_model.ElasticNet(max_iter=1e4, l1_ratio=0.2, positive=False) # idk lol
     
     subset = np.concatenate( [yes_tmk_idx, np.random.choice(not_tmk_idx, ntmk, replace=False)] )
     subsets[i] = subset
@@ -178,9 +178,15 @@ for i in range(nboots):
 
 # build long dataframe solely for the purposes of visualization.
 df_results = pandas.DataFrame(data=models_coef_,columns=features).melt(var_name='Indicator', value_name='Coefficient')
-#df_results['Category'] = [{'X':''}]
+df_results['Indicator_group'] = [{'X':'S'}.get(v[0],v[0]) for v in df_results['Indicator']]
 
 #
+fig,ax = plt.subplots(figsize=(16,8), constrained_layout=True)
+seaborn.barplot(ax=ax, data=df_results, x='Indicator', y='Coefficient', alpha=0.5, hue='Indicator_group', palette='tab10', width=0.95)
 
-#seaborn.swarmplot(data=df_results, x='Indicator', y='Coefficient')
+# figure polish
+ax.set_xticklabels(ax.get_xticklabels(), rotation=60, ha='right')
+ax.set_title('FSI indicator feature importance (predicting TMK year%i)'%k, loc='left', fontsize=24)
+seaborn.move_legend(ax, loc='upper left')
 
+fig.savefig('FSI_predicting_TMK1.png', bbox_inches='tight')

--- a/fragile_state_index/fsi_analysis3.py
+++ b/fragile_state_index/fsi_analysis3.py
@@ -32,6 +32,11 @@ load_fsi.shorten_indicators(df_fsi)
 
 df_fsi = load_fsi.to_long(df_fsi)
 
+# convert to "multi-index" pivot table; a 3D object (Country, Year, Indicator);
+# accessed first by Year; then, rows are the data for that year.
+df_fsi_pivot = df_fsi.pivot_table(values='value', index='Country', columns=['Year','Indicator'])
+
+
 '''
 RESEARCH QUESTION:
     
@@ -59,8 +64,11 @@ L = 1
 df_p = df_tmk2.pivot_table(values='tmk', index='country', columns='year')
 df_p.fillna(0., inplace=True)
 
+tmk_minyear = df_p.columns.min()
+tmk_maxyear = 2023 # hard code...
+
 # pad with non-TMK years where needed
-for i in range(2006,2023 + 1):
+for i in range(tmk_minyear,tmk_maxyear + 1):
     if i not in df_p.columns:
         df_p[i] = np.zeros(df_p.shape[0])
 
@@ -74,15 +82,41 @@ _df_null = pandas.DataFrame(data = np.zeros( (len(non_tmk_countries), df_p.shape
 
 #
 df_p = df_p.append(_df_null)
+df_p.sort_index(inplace=True)
 
-X = []
-y = []
+# TODO: Code assumes row ordering is consistent.
+# CANNOT PROCEED WITH CODE AS-IS IF THIS IS NOT TRUE.
+assert all(df_p.index == df_fsi_pivot.index)
+
+#
+
+Xstack = []
+ystack = []
 # for each year i after 2006+k+L-1 (inclusive),
+for i in range(tmk_minyear+k+L-1, tmk_maxyear+1):
     # y_i : year i from TMK dataset
+    y_i = df_p[i].values
+    
     # X_i : year i-L-k+1 to year i-L inclusive from the FSI dataset.
+    # array dimensions go (year, country, indicator)
+    X_i = np.array([ df_fsi_pivot[i-L-k+1+j].values for j in range(k)])
+    # glue together data for a single country
+    X_i = np.concatenate(X_i, axis=1)
+    
+    # Filter out any missing data.
+    to_keep = ~np.any(np.isnan(X_i), axis=1)
+    
+    Xstack.append( X_i[to_keep] )
+    ystack.append( y_i[to_keep] )
+    
     # e.g. if k=2, L=1, then start at 2008 (prediction year); 
     # years 2008-1-2+1 (=2006) to 2008-1 (=2007) (TMI data years).
+#
 
+X = np.concatenate(Xstack, axis=0)
+y = np.concatenate(ystack)
 
+# must have no NaN at this point!
+assert( np.all(~np.isnan(X)) and np.all(~np.isnan(y)) )
 
-
+# final labeled data set (!!)

--- a/fragile_state_index/load_fsi.py
+++ b/fragile_state_index/load_fsi.py
@@ -44,6 +44,9 @@ def load(folder=DATA_FOLDER):
     df = pandas.concat(dfs, axis=0, ignore_index=True)
     df.drop(columns=['Change from Previous Year'], inplace=True)
     
+    # country replacements.
+    df.replace({"Côte d'Ivoire": "Cote d'Ivoire"}, inplace=True)
+    
     # country name "Kyrgyzstan" only has data for 2021-2022;
     # "Kyrgyz Republic" is complete. 
     # No apparent difference in country sovereignty.

--- a/fragile_state_index/load_tmk.py
+++ b/fragile_state_index/load_tmk.py
@@ -4,6 +4,13 @@ import pandas
 
 DATA_FOLDER = os.path.abspath('../data')
 
+# manual codings from TMK country names to FSI country names
+tmk_to_fsi = {
+    'DR Congo (Zaire)': 'Congo Democratic Republic',
+    'Ivory Coast': "Cote d'Ivoire",
+    'Myanmar (Burma)': "Myanmar"
+}
+
 def load(folder=DATA_FOLDER):
     fname = os.path.join(DATA_FOLDER, 'tmk_events_release_1.1.xls')
     df = pandas.read_excel(fname)
@@ -12,4 +19,33 @@ def load(folder=DATA_FOLDER):
     mask = df['country'].notna()
     df = df[mask]
     df['country'] = df['country'].str.strip()
+    
+    df.replace(tmk_to_fsi, inplace=True)
+    
     return df
+
+def expand_countries(mydf):
+    '''
+    Expand on column "country", duplicating unique rows for 
+    each country. 
+    
+    CAUTION: as of 6 July, other columns which contain information 
+        about the instigator, government or non-government actors, 
+        etc, gets confused/lost as these get mindlessly copied.
+        Is a TODO to be more careful about the expansion happening here.
+    
+    (Conflict names recoverable via column "tmk_id"... I think?)
+    
+    Input:
+        mydf : dataframe; the result of load()
+    Output:
+        df_ucountry : dataframe processed in the manner described above.
+    '''
+    rows = []
+    for row in mydf.iloc:
+        for e in row['country'].split(', '):
+            newrow = row.copy()
+            newrow['country'] = e
+            rows.append(newrow)
+    df_ucountry = pandas.DataFrame(rows)
+    return df_ucountry


### PR DESCRIPTION
The end task is to predict the "tmk" (binary 0/1) or "tmk.ordinal" (an assumed scalar 0 through 8) which associates with the severity of a TMK event, given one or more years of Fragile State Index scores. There are various nuances and issues at this point:
- data points may be indicating a TMK event even though it has already been happening;
- various model parameters are arbitrarily chosen (strength of l1 regularization for example);
- Parameters "k" and "L" (controlling number of years, and delay until prediction, are a little unintuitive to think about. For example L=3 and k=1 corresponds to making a prediction 3 years out using a single years worth of data, but the code is "backwards" looking. Not really an issue, but has to be interpreted carefully. Figures created use opposite notation, currently.
- Questions about accuracy or otherwise the quality of projections are not done. Proper cross-validation (separate training and test sets) as well as, probably, another fold of bootstrapping, needs to be done. The current figures use bootstrapping for the purpose of equalizing size of the positive/negative classes (58 or 59 TMK-positive examples; hence {big number of} bootstraps of 58~59 TMK-negative events are done)

The dataset module simplifies the task by having a callable function which outputs the "X" and "y" (data vectors and output value) for the purpose of regression or classification; naming convention following scikit-learn. Conceivably for future machine learning or time series analysis tasks, the main effort of creating the usable data can go in here.

Various other polishes done 