### PR TITLE
prelim evaluation and comparison against EWP

### DIFF
--- a/fragile_state_index/datasets.py
+++ b/fragile_state_index/datasets.py
@@ -190,3 +190,30 @@ def is_not_ongoing(event, prior_event_list, k=1, L=1):
             return False
     return True
 
+def ewp_2022_23_raw(fname="sra_2023.csv"):
+    '''
+    Loads the Early Warning Project 2023 projections/scores 
+    csv file, available at 
+    
+        https://earlywarningproject.ushmm.org/downloads
+        
+    Version accessed/successful in loading in this 
+    version of our code is circa July 2023.
+    
+    Outputs:
+        df : pandas dataframe of that csv file.
+    '''
+    df = pandas.read_csv(fname)
+    return df
+
+def our_bootstrap_results_k1_L1(fname="bootstrap_pred_results_k1_L1.csv"):
+    '''
+    Loads the summary file of our ensemble/bootstrap 
+    predictions for TMK events with a 1-year forecast, 
+    using 1 year worth of Fragile State Index data.
+    
+    Outputs:
+        df : pandas dataframe of that csv file.
+    '''
+    df = pandas.read_csv(fname)
+    return df

--- a/fragile_state_index/fsi_map_vis.py
+++ b/fragile_state_index/fsi_map_vis.py
@@ -1,0 +1,79 @@
+'''
+
+Goal: 
+    Compare Early Warning project scores for each 
+    country to those produced during our bootstrapping.
+    
+    There are various nuances in differences in 
+    methodology, but the main interest is to answer 
+    how consistent our scorings are with theirs, 
+    for the easiest to handle data set (2022-2023)
+'''
+
+import pandas
+
+import numpy as np
+
+#import seaborn
+import geopandas
+from matplotlib import pyplot as plt
+
+#import datasets
+#df_our = datasets.our_bootstrap_results_k1_L1()
+
+df_our = pandas.read_csv("bootstrap_pred_results_k1_L1.csv")
+df_our = df_our[df_our['year']==2022]
+
+# aggregated scores.
+scores_2022 = df_our.groupby('country').agg({"pred_prob":np.nanmean})
+std_2022 = df_our.groupby('country').agg({"pred_prob":np.std})
+
+# country boundaries via World Bank Official Boundaries;
+# https://datacatalog.worldbank.org/search/dataset/0038272/World-Bank-Official-Boundaries
+#
+
+mapper = scores_2022.to_dict()['pred_prob']
+
+
+
+gdf = geopandas.read_file('WB_Boundaries_GeoJSON_lowres/WB_countries_Admin0_lowres.geojson')
+
+# Country name replacements only to align results
+country_name_map = {'United States of America': 'United States',
+             'Democratic Republic of the Congo': 'Congo Democratic Republic',
+             'Republic of the Congo': 'Congo Republic',
+             'Czech Republic': 'Czechia',
+             "People's Republic of China": "China",
+             "Ivory Coast": "Cote d'Ivoire",
+             "Kyrgyzstan": "Kyrgyz Republic",
+             "Guinea-Bissau": "Guinea Bissau",
+             "Slovakia": "Slovak Republic",
+#             "North Macedonia": 
+#             "Kosovo": 
+             }
+
+    
+gdf.replace(country_name_map, inplace=True)
+
+gdf.set_index("NAME_EN", inplace=True)
+gdf['scores'] = gdf.index.map(mapper)
+
+###
+# the plot
+fig,ax = plt.subplots(figsize=(10,6), constrained_layout=True)
+for v in ax.spines.values():
+    v.set_visible(False)
+ax.set(xticks=[], yticks=[])
+
+gdf[gdf['scores'].isna()].plot(fc='#ccc', ec='#999', ax=ax, lw=0.5) # plots null/unmapped values
+
+# TODO: (more of a dream); Peirce quinuncial projection.
+# Not clear if it's possible with built-ins in geopandas right now (July 2023)
+#gdf=gdf.to_crs("ESRI:54090")
+
+gdf.plot(column='scores', cmap=plt.cm.cividis, ax=ax)
+
+# save
+fig.savefig('fsi_tmk_scoring_2022.png', bbox_inches='tight')
+fig.savefig('fsi_tmk_scoring_2022.pdf', bbox_inches='tight')
+

--- a/fragile_state_index/fsi_map_vis.py
+++ b/fragile_state_index/fsi_map_vis.py
@@ -74,6 +74,6 @@ gdf[gdf['scores'].isna()].plot(fc='#ccc', ec='#999', ax=ax, lw=0.5) # plots null
 gdf.plot(column='scores', cmap=plt.cm.cividis, ax=ax)
 
 # save
-fig.savefig('fsi_tmk_scoring_2022.png', bbox_inches='tight')
-fig.savefig('fsi_tmk_scoring_2022.pdf', bbox_inches='tight')
+fig.savefig('fsi_tmk_scoring_map_2022.png', bbox_inches='tight')
+fig.savefig('fsi_tmk_scoring_map_2022.pdf', bbox_inches='tight')
 

--- a/fragile_state_index/fsi_vs_ewp_2022.py
+++ b/fragile_state_index/fsi_vs_ewp_2022.py
@@ -1,0 +1,68 @@
+'''
+
+Goal: 
+    Compare Early Warning project scores for each 
+    country to those produced during our bootstrapping.
+    
+    There are various nuances in differences in 
+    methodology, but the main interest is to answer 
+    how consistent our scorings are with theirs, 
+    for the easiest to handle data set (2022-2023)
+'''
+
+import pandas
+import datasets
+import numpy as np
+
+import seaborn
+from matplotlib import pyplot as plt
+
+
+df_our = datasets.our_bootstrap_results_k1_L1()
+df_ewp = datasets.ewp_2022_23_raw()
+
+####
+# cleanup
+
+# Country renamings only to aid score comparison
+df_ewp.replace({"Burma/Myanmar": "Myanmar"}, inplace=True)
+df_ewp.sort_values('country', inplace=True)
+df_ewp.set_index('country', inplace=True)
+
+ewp_countries = df_ewp.index.unique()
+
+# TODO: strictly necessary?
+ewp_mask = df_our['country'].isin(ewp_countries)
+df_our = df_our[ewp_mask]
+
+#####
+# numerical score dict
+
+# For analysis, insert columns in *our* data set 
+# where EWP scores get mapped via dictionary.
+
+for ewp_col in ['risk_in_2022', 'risk_in_2022_23']:
+    mappable = df_ewp[ewp_col].to_dict()
+    df_our['ewp_'+ewp_col] = df_our['country'].map(mappable)
+    
+####
+# visualization
+plt.style.use('seaborn-whitegrid')
+plt.rcParams.update({'font.size': 18})
+fig,ax = plt.subplots(figsize=(10,8), constrained_layout=True)
+
+#
+target_year = 2022
+target_ewp_col = 'ewp_risk_in_2022'
+df_compare = df_our[ df_our['year']==target_year ]
+
+#ax.scatter(df_compare['pred_prob'], df_compare['ewp_risk_in_2022_23'], s=10, alpha=0.4)
+my_cm = plt.cm.magma_r.copy()
+my_cm.set_under([0,0,0,0])
+my_cm.set_bad([0,0,0,0])
+plot_obj = ax.hexbin(df_compare['pred_prob'], df_compare[target_ewp_col], gridsize=20, bins='log', cmap=my_cm, vmin=2)
+ax.set(xlabel='Risk; FSI + TMK + LR', ylabel='Risk; EWP')
+
+fig.colorbar(plot_obj, label='Count')
+fig.savefig('ewp_vs_fsi_v1_%i.png'%target_year, bbox_inches='tight')
+fig.savefig('ewp_vs_fsi_v1_%i.pdf'%target_year, bbox_inches='tight')


### PR DESCRIPTION
Updates here: 
- a hexbin plot of by-eye comparison of how scores relate between EWP scores, and ours (FSI indicators into logistic regression to predict TMK). In some sense, if they were making the "same predictions", we'd expect a line (not necessarily y=x).
- a heatmap of the average scores produced by us for year 2022 in predicting 2023.
